### PR TITLE
1 update to date api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-jotform-api-ruby 
+jotform-api-ruby
 ===============
-[JotForm API](http://api.jotform.com/docs/) - Ruby Client
+[Jotform API](https://api.jotform.com/docs/) - Ruby Client
 
 
 ### Installation
@@ -12,7 +12,7 @@ Install via git clone:
 
 ### Documentation
 
-You can find the docs for the API of this client at [http://api.jotform.com/docs/](http://api.jotform.com/docs)
+You can find the docs for the API at [https://api.jotform.com/docs/](https://api.jotform.com/docs/).
 
 ### Authentication
 
@@ -52,8 +52,22 @@ end
 ```    
 
     
-First the _JotForm_ class is included from the _jotform-api-ruby/JotForm.rb_ file. This class provides access to JotForm's API. You have to create an API client instance with your API key. 
+First the _Jotform_ class is included from _lib/jotform.rb_. This class provides access to Jotform's API. You have to create an API client instance with your API key.
 In case of an exception (wrong authentication etc.), you can catch it or let it fail with a fatal error.
+
+### Supported Endpoints
+
+As of **March 8, 2026**, this client is aligned with the public endpoint groups listed in `https://api.jotform.com/docs/`:
+
+- `/user` (including usage, forms, submissions, subusers, folders, reports, settings, settings key, labels, invoices, register, login, logout)
+- `/form` (including questions, properties, submissions, files, webhooks, webhooks delete, clone, reports)
+- `/submission` (get, edit, delete)
+- `/report` (get, delete)
+- `/folder` (get, create, update, delete)
+- `/label` (get, create, update, delete, resources, add/remove resources)
+- `/system` (`/system/plan/{planName}`)
+
+Note: API docs may change over time. When Jotform adds new endpoints, this client may require updates to stay in sync.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ end
     
 First the _JotForm_ class is included from the _jotform-api-ruby/JotForm.rb_ file. This class provides access to JotForm's API. You have to create an API client instance with your API key. 
 In case of an exception (wrong authentication etc.), you can catch it or let it fail with a fatal error.
+
+### License
+
+This project is licensed under the Apache License 2.0. See `LICENSE.txt` for details.

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'rake/testtask'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
+  t.libs << 'lib'
 end
 
 desc "Run tests"

--- a/jotform_api.gemspec
+++ b/jotform_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = "jotform_api"
-  s.version            = "1.0.2"
+  s.version            = "1.1.0"
 
   s.required_ruby_version = ">= 2.6"
   s.authors = ["Marcelo Miqueles"]

--- a/jotform_api.gemspec
+++ b/jotform_api.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.6.2}
   s.summary = %q{jotform!}
 
-  s.license = "MIT"
+  s.license = "Apache-2.0"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
@@ -25,4 +25,3 @@ Gem::Specification.new do |s|
   else
   end
 end
-

--- a/lib/jotform.rb
+++ b/lib/jotform.rb
@@ -41,7 +41,7 @@ class Jotform
   end
 
   def getUsage
-    return _executeGetRequest("user/usage");
+    return _executeGetRequest("user/usage")
   end
 
   def getForms
@@ -93,11 +93,7 @@ class Jotform
   end
 
   def getFormSubmissions(formID)
-    return _executeGetRequest("form/"+ formID +"/submissions")
-  end
-
-  def getFormSubmissions(formID)
-    return _executeGetRequest("form/"+ formID +"/submissions")
+    return _executeGetRequest("form/" + formID + "/submissions")
   end
 
   def getFormFiles(formID)
@@ -121,11 +117,11 @@ class Jotform
   end
 
   def createFormWebhook(formID, webhookURL)
-    return _executePostRequest("form/"+formID+"/webhooks",{"webhookURL" => webhookURL} );
+    return _executePostRequest("form/"+formID+"/webhooks",{"webhookURL" => webhookURL} )
   end
 
   def createFormSubmissions(formID, submission)
-    return _executePostRequest("form/"+ formID +"/submissions", submission);
+    return _executePostRequest("form/" + formID + "/submissions", submission)
   end
 end
 

--- a/lib/jotform.rb
+++ b/lib/jotform.rb
@@ -18,6 +18,25 @@ class Jotform
       response = Net::HTTP.get_response(url)
     elsif type == "POST"
       response = Net::HTTP.post_form(url, parameters)
+    elsif type == "PUT" || type == "DELETE"
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = (url.scheme == "https")
+
+      if type == "PUT"
+        request = Net::HTTP::Put.new(url.request_uri)
+        if parameters
+          if parameters.is_a?(String)
+            request.body = parameters
+          else
+            request.body = JSON.generate(parameters)
+          end
+          request["Content-Type"] = "application/json"
+        end
+      else
+        request = Net::HTTP::Delete.new(url.request_uri)
+      end
+
+      response = http.request(request)
     end
 
     if response.kind_of? Net::HTTPSuccess
@@ -34,6 +53,14 @@ class Jotform
 
   def _executePostRequest(endpoint, parameters = [])
     return _executeHTTPRequest(endpoint,parameters, "POST")
+  end
+
+  def _executePutRequest(endpoint, parameters = [])
+    return _executeHTTPRequest(endpoint,parameters, "PUT")
+  end
+
+  def _executeDeleteRequest(endpoint, parameters = [])
+    return _executeHTTPRequest(endpoint,parameters, "DELETE")
   end
 
   def getUser
@@ -70,6 +97,10 @@ class Jotform
 
   def getHistory
     return _executeGetRequest("user/history")
+  end
+
+  def getLabels
+    return _executeGetRequest("user/labels")
   end
 
   def getForm(formID)
@@ -116,12 +147,44 @@ class Jotform
     return _executeGetRequest("folder/"+folderID)
   end
 
+  def getSystemPlan(planName)
+    return _executeGetRequest("system/plan/"+planName)
+  end
+
+  def getLabel(labelID)
+    return _executeGetRequest("label/"+labelID)
+  end
+
+  def getLabelResources(labelID)
+    return _executeGetRequest("label/"+labelID+"/resources")
+  end
+
   def createFormWebhook(formID, webhookURL)
     return _executePostRequest("form/"+formID+"/webhooks",{"webhookURL" => webhookURL} )
   end
 
   def createFormSubmissions(formID, submission)
     return _executePostRequest("form/" + formID + "/submissions", submission)
+  end
+
+  def createLabel(labelProperties)
+    return _executePostRequest("label", labelProperties)
+  end
+
+  def updateLabel(labelID, labelProperties)
+    return _executePutRequest("label/" + labelID, labelProperties)
+  end
+
+  def addResourcesToLabel(labelID, resources)
+    return _executePutRequest("label/" + labelID + "/add-resources", { "resources" => resources })
+  end
+
+  def removeResourcesFromLabel(labelID, resources)
+    return _executePutRequest("label/" + labelID + "/remove-resources", { "resources" => resources })
+  end
+
+  def deleteLabel(labelID)
+    return _executeDeleteRequest("label/" + labelID)
   end
 end
 

--- a/lib/jotform.rb
+++ b/lib/jotform.rb
@@ -95,12 +95,24 @@ class Jotform
     return _executeGetRequest("user/settings")
   end
 
+  def getUserSetting(settingKey)
+    return _executeGetRequest("user/settings/" + settingKey)
+  end
+
+  def updateSettings(settings)
+    return _executePostRequest("user/settings", settings)
+  end
+
   def getHistory
     return _executeGetRequest("user/history")
   end
 
   def getLabels
     return _executeGetRequest("user/labels")
+  end
+
+  def getInvoices
+    return _executeGetRequest("user/invoices")
   end
 
   def getForm(formID)
@@ -135,6 +147,10 @@ class Jotform
     return _executeGetRequest("form/"+formID+"/webhooks")
   end
 
+  def getFormReports(formID)
+    return _executeGetRequest("form/" + formID + "/reports")
+  end
+
   def getSubmission(sid)
     return _executeGetRequest("submission/"+sid)
   end
@@ -167,6 +183,21 @@ class Jotform
     return _executePostRequest("form/" + formID + "/submissions", submission)
   end
 
+  def createFormSubmission(formID, submission)
+    formatted_submission = {}
+    submission.each do |key, value|
+      key_string = key.to_s
+      if key_string.include?("_")
+        qid, field_type = key_string.split("_", 2)
+        formatted_submission["submission[#{qid}][#{field_type}]"] = value
+      else
+        formatted_submission["submission[#{key_string}]"] = value
+      end
+    end
+
+    return _executePostRequest("form/" + formID + "/submissions", formatted_submission)
+  end
+
   def createLabel(labelProperties)
     return _executePostRequest("label", labelProperties)
   end
@@ -185,6 +216,137 @@ class Jotform
 
   def deleteLabel(labelID)
     return _executeDeleteRequest("label/" + labelID)
+  end
+
+  def createFolder(folderProperties)
+    return _executePostRequest("folder", folderProperties)
+  end
+
+  def updateFolder(folderID, folderProperties)
+    return _executePutRequest("folder/" + folderID, folderProperties)
+  end
+
+  def deleteFolder(folderID)
+    return _executeDeleteRequest("folder/" + folderID)
+  end
+
+  def addFormsToFolder(folderID, formIDs)
+    return updateFolder(folderID, { "forms" => formIDs })
+  end
+
+  def addFormToFolder(folderID, formID)
+    return addFormsToFolder(folderID, [formID])
+  end
+
+  def deleteFormWebhook(formID, webhookID)
+    return _executeDeleteRequest("form/" + formID + "/webhooks/" + webhookID)
+  end
+
+  def deleteSubmission(submissionID)
+    return _executeDeleteRequest("submission/" + submissionID)
+  end
+
+  def editSubmission(submissionID, submission)
+    formatted_submission = {}
+    submission.each do |key, value|
+      key_string = key.to_s
+      if key_string.include?("_") && key_string != "created_at"
+        qid, field_type = key_string.split("_", 2)
+        formatted_submission["submission[#{qid}][#{field_type}]"] = value
+      else
+        formatted_submission["submission[#{key_string}]"] = value
+      end
+    end
+
+    return _executePostRequest("submission/" + submissionID, formatted_submission)
+  end
+
+  def cloneForm(formID)
+    return _executePostRequest("form/" + formID + "/clone", nil)
+  end
+
+  def deleteFormQuestion(formID, qid)
+    return _executeDeleteRequest("form/" + formID + "/question/" + qid)
+  end
+
+  def createFormQuestion(formID, question)
+    formatted_question = {}
+    question.each do |key, value|
+      formatted_question["question[#{key}]"] = value
+    end
+
+    return _executePostRequest("form/" + formID + "/questions", formatted_question)
+  end
+
+  def createFormQuestions(formID, questions)
+    return _executePutRequest("form/" + formID + "/questions", questions)
+  end
+
+  def editFormQuestion(formID, qid, questionProperties)
+    formatted_question = {}
+    questionProperties.each do |key, value|
+      formatted_question["question[#{key}]"] = value
+    end
+
+    return _executePostRequest("form/" + formID + "/question/" + qid, formatted_question)
+  end
+
+  def setFormProperties(formID, formProperties)
+    formatted_properties = {}
+    formProperties.each do |key, value|
+      formatted_properties["properties[#{key}]"] = value
+    end
+
+    return _executePostRequest("form/" + formID + "/properties", formatted_properties)
+  end
+
+  def setMultipleFormProperties(formID, formProperties)
+    return _executePutRequest("form/" + formID + "/properties", formProperties)
+  end
+
+  def createForm(form)
+    formatted_form = {}
+    form.each do |section, values|
+      values.each do |key, value|
+        if section.to_s == "properties"
+          formatted_form["#{section}[#{key}]"] = value
+        else
+          value.each do |sub_key, sub_value|
+            formatted_form["#{section}[#{key}][#{sub_key}]"] = sub_value
+          end
+        end
+      end
+    end
+
+    return _executePostRequest("user/forms", formatted_form)
+  end
+
+  def createForms(forms)
+    return _executePutRequest("user/forms", forms)
+  end
+
+  def deleteForm(formID)
+    return _executeDeleteRequest("form/" + formID)
+  end
+
+  def registerUser(userDetails)
+    return _executePostRequest("user/register", userDetails)
+  end
+
+  def loginUser(credentials)
+    return _executePostRequest("user/login", credentials)
+  end
+
+  def logoutUser
+    return _executeGetRequest("user/logout")
+  end
+
+  def createReport(formID, report)
+    return _executePostRequest("form/" + formID + "/reports", report)
+  end
+
+  def deleteReport(reportID)
+    return _executeDeleteRequest("report/" + reportID)
   end
 end
 

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -115,6 +115,105 @@ class JotformTest < Test::Unit::TestCase
     assert_equal({ "submissionID" => "sub_1" }, result)
   end
 
+  def test_post_endpoint_wrappers_call_expected_paths
+    cases = [
+      [:updateSettings, [{ "language" => "en" }], "user/settings"],
+      [:registerUser, [{ "username" => "john", "password" => "secret" }], "user/register"],
+      [:loginUser, [{ "username" => "john", "password" => "secret", "appName" => "app", "access" => "readOnly" }], "user/login"],
+      [:cloneForm, ["123"], "form/123/clone"],
+      [:createReport, ["123", { "title" => "My Report", "list_type" => "grid" }], "form/123/reports"],
+      [:createFolder, [{ "name" => "Ops", "color" => "#FFFFFF" }], "folder"],
+      [:createFormWebhook, ["123", "https://callback.test/hook"], "form/123/webhooks"]
+    ]
+
+    cases.each do |method_name, args, path|
+      captured_uri = nil
+      captured_params = nil
+
+      stub_net_http_method(:post_form) do |uri, params|
+        captured_uri = uri
+        captured_params = params
+        FakeSuccessResponse.new({ "content" => { "endpoint" => path } }.to_json)
+      end
+
+      result = @jotform.send(method_name, *args)
+
+      assert_equal("http://example.com/v9/#{path}?apiKey=test-api-key", captured_uri.to_s)
+      assert_not_nil(captured_params) unless method_name == :cloneForm
+      assert_equal({ "endpoint" => path }, result)
+
+      restore_net_http_method(:post_form)
+    end
+  end
+
+  def test_submission_and_form_payload_transformations
+    captured_uri = nil
+    captured_params = nil
+
+    stub_net_http_method(:post_form) do |uri, params|
+      captured_uri = uri
+      captured_params = params
+      FakeSuccessResponse.new({ "content" => { "ok" => true } }.to_json)
+    end
+
+    @jotform.createFormSubmission("100", { "1" => "A", "2_first" => "John", "3_last" => "Doe" })
+    assert_equal("http://example.com/v9/form/100/submissions?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal(
+      {
+        "submission[1]" => "A",
+        "submission[2][first]" => "John",
+        "submission[3][last]" => "Doe"
+      },
+      captured_params
+    )
+
+    @jotform.editSubmission("sub_1", { "2_first" => "Jane", "created_at" => "2025-01-01" })
+    assert_equal("http://example.com/v9/submission/sub_1?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal(
+      {
+        "submission[2][first]" => "Jane",
+        "submission[created_at]" => "2025-01-01"
+      },
+      captured_params
+    )
+
+    @jotform.createFormQuestion("100", { "type" => "control_head", "text" => "Header" })
+    assert_equal("http://example.com/v9/form/100/questions?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal({ "question[type]" => "control_head", "question[text]" => "Header" }, captured_params)
+
+    @jotform.editFormQuestion("100", "7", { "text" => "Updated" })
+    assert_equal("http://example.com/v9/form/100/question/7?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal({ "question[text]" => "Updated" }, captured_params)
+
+    @jotform.setFormProperties("100", { "thankurl" => "https://example.com/thanks", "formWidth" => "650" })
+    assert_equal("http://example.com/v9/form/100/properties?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal(
+      {
+        "properties[thankurl]" => "https://example.com/thanks",
+        "properties[formWidth]" => "650"
+      },
+      captured_params
+    )
+
+    form_payload = {
+      "questions" => { "0" => { "type" => "control_head", "text" => "Form Title" } },
+      "properties" => { "title" => "New Form" },
+      "emails" => { "0" => { "type" => "notification", "to" => "noreply@jotform.com" } }
+    }
+    @jotform.createForm(form_payload)
+    assert_equal("http://example.com/v9/user/forms?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal(
+      {
+        "questions[0][type]" => "control_head",
+        "questions[0][text]" => "Form Title",
+        "properties[title]" => "New Form",
+        "emails[0][type]" => "notification",
+        "emails[0][to]" => "noreply@jotform.com"
+      },
+      captured_params
+    )
+  end
+
   def test_create_label_posts_payload_and_returns_content
     captured_uri = nil
     captured_params = nil
@@ -174,6 +273,30 @@ class JotformTest < Test::Unit::TestCase
     assert_equal({ "resources" => resources }.to_json, captured[:request].body)
     assert_equal({ "ok" => true }, remove_result)
 
+    @jotform.updateFolder("folder_1", { "name" => "My Folder" })
+    assert_equal("/v9/folder/folder_1?apiKey=test-api-key", captured[:request].path)
+    assert_equal({ "name" => "My Folder" }.to_json, captured[:request].body)
+
+    @jotform.addFormsToFolder("folder_1", ["f1", "f2"])
+    assert_equal("/v9/folder/folder_1?apiKey=test-api-key", captured[:request].path)
+    assert_equal({ "forms" => ["f1", "f2"] }.to_json, captured[:request].body)
+
+    @jotform.addFormToFolder("folder_1", "f3")
+    assert_equal("/v9/folder/folder_1?apiKey=test-api-key", captured[:request].path)
+    assert_equal({ "forms" => ["f3"] }.to_json, captured[:request].body)
+
+    @jotform.createForms([{ "properties" => { "title" => "Bulk" } }])
+    assert_equal("/v9/user/forms?apiKey=test-api-key", captured[:request].path)
+    assert_equal([{ "properties" => { "title" => "Bulk" } }].to_json, captured[:request].body)
+
+    @jotform.createFormQuestions("100", { "questions" => {} })
+    assert_equal("/v9/form/100/questions?apiKey=test-api-key", captured[:request].path)
+    assert_equal({ "questions" => {} }.to_json, captured[:request].body)
+
+    @jotform.setMultipleFormProperties("100", { "properties" => { "labelWidth" => "150" } })
+    assert_equal("/v9/form/100/properties?apiKey=test-api-key", captured[:request].path)
+    assert_equal({ "properties" => { "labelWidth" => "150" } }.to_json, captured[:request].body)
+
     raw_payload = '{"name":"Raw Label"}'
     raw_result = @jotform.updateLabel("label_1", raw_payload)
     assert_equal("/v9/label/label_1?apiKey=test-api-key", captured[:request].path)
@@ -185,18 +308,45 @@ class JotformTest < Test::Unit::TestCase
     assert_kind_of(Net::HTTP::Delete, captured[:request])
     assert_equal("/v9/label/label_1?apiKey=test-api-key", captured[:request].path)
     assert_equal({ "ok" => true }, delete_result)
+
+    @jotform.deleteFolder("folder_1")
+    assert_kind_of(Net::HTTP::Delete, captured[:request])
+    assert_equal("/v9/folder/folder_1?apiKey=test-api-key", captured[:request].path)
+
+    @jotform.deleteFormWebhook("100", "wh_1")
+    assert_kind_of(Net::HTTP::Delete, captured[:request])
+    assert_equal("/v9/form/100/webhooks/wh_1?apiKey=test-api-key", captured[:request].path)
+
+    @jotform.deleteSubmission("sub_1")
+    assert_kind_of(Net::HTTP::Delete, captured[:request])
+    assert_equal("/v9/submission/sub_1?apiKey=test-api-key", captured[:request].path)
+
+    @jotform.deleteFormQuestion("100", "7")
+    assert_kind_of(Net::HTTP::Delete, captured[:request])
+    assert_equal("/v9/form/100/question/7?apiKey=test-api-key", captured[:request].path)
+
+    @jotform.deleteForm("100")
+    assert_kind_of(Net::HTTP::Delete, captured[:request])
+    assert_equal("/v9/form/100?apiKey=test-api-key", captured[:request].path)
+
+    @jotform.deleteReport("rep_1")
+    assert_kind_of(Net::HTTP::Delete, captured[:request])
+    assert_equal("/v9/report/rep_1?apiKey=test-api-key", captured[:request].path)
   end
 
   def test_get_endpoint_wrappers_call_expected_paths
     cases = [
       [:getUsage, [], "user/usage"],
       [:getLabels, [], "user/labels"],
+      [:getInvoices, [], "user/invoices"],
       [:getSubmissions, [], "user/submissions"],
       [:getSubusers, [], "user/subusers"],
       [:getFolders, [], "user/folders"],
       [:getReports, [], "user/reports"],
       [:getSettings, [], "user/settings"],
+      [:getUserSetting, ["language"], "user/settings/language"],
       [:getHistory, [], "user/history"],
+      [:logoutUser, [], "user/logout"],
       [:getSystemPlan, ["FREE"], "system/plan/FREE"],
       [:getForm, ["123"], "form/123"],
       [:getFormQuestions, ["123"], "form/123/questions"],
@@ -206,6 +356,7 @@ class JotformTest < Test::Unit::TestCase
       [:getFormSubmissions, ["123"], "form/123/submissions"],
       [:getFormFiles, ["123"], "form/123/files"],
       [:getFormWebhooks, ["123"], "form/123/webhooks"],
+      [:getFormReports, ["123"], "form/123/reports"],
       [:getReport, ["r1"], "report/r1"],
       [:getFolder, ["fld1"], "folder/fld1"],
       [:getLabel, ["lbl1"], "label/lbl1"],

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -27,6 +27,7 @@ class JotformTest < Test::Unit::TestCase
   def teardown
     restore_net_http_method(:get_response)
     restore_net_http_method(:post_form)
+    restore_net_http_method(:new)
   end
 
   def test_get_user_calls_expected_endpoint_and_returns_content
@@ -114,15 +115,89 @@ class JotformTest < Test::Unit::TestCase
     assert_equal({ "submissionID" => "sub_1" }, result)
   end
 
+  def test_create_label_posts_payload_and_returns_content
+    captured_uri = nil
+    captured_params = nil
+    payload = { "name" => "IT Operations", "color" => "#FFDC7B" }
+
+    stub_net_http_method(:post_form) do |uri, params|
+      captured_uri = uri
+      captured_params = params
+      FakeSuccessResponse.new({ "content" => { "id" => "lbl_1" } }.to_json)
+    end
+
+    result = @jotform.createLabel(payload)
+
+    assert_equal("http://example.com/v9/label?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal(payload, captured_params)
+    assert_equal({ "id" => "lbl_1" }, result)
+  end
+
+  def test_put_and_delete_label_requests_use_expected_paths_and_payloads
+    captured = {}
+
+    stub_net_http_method(:new) do |host, port|
+      captured[:host] = host
+      captured[:port] = port
+
+      http = Object.new
+      http.define_singleton_method(:use_ssl=) do |value|
+        captured[:use_ssl] = value
+      end
+      http.define_singleton_method(:request) do |request|
+        captured[:request] = request
+        FakeSuccessResponse.new({ "content" => { "ok" => true } }.to_json)
+      end
+      http
+    end
+
+    update_payload = { "name" => "Workplace Operations", "color" => "#23FFDD" }
+    update_result = @jotform.updateLabel("label_1", update_payload)
+
+    assert_equal("example.com", captured[:host])
+    assert_equal(80, captured[:port])
+    assert_equal(false, captured[:use_ssl])
+    assert_kind_of(Net::HTTP::Put, captured[:request])
+    assert_equal("/v9/label/label_1?apiKey=test-api-key", captured[:request].path)
+    assert_equal(update_payload.to_json, captured[:request].body)
+    assert_equal("application/json", captured[:request]["Content-Type"])
+    assert_equal({ "ok" => true }, update_result)
+
+    resources = [{ "id" => "251464995493876", "type" => "form" }]
+    add_result = @jotform.addResourcesToLabel("label_1", resources)
+    assert_equal("/v9/label/label_1/add-resources?apiKey=test-api-key", captured[:request].path)
+    assert_equal({ "resources" => resources }.to_json, captured[:request].body)
+    assert_equal({ "ok" => true }, add_result)
+
+    remove_result = @jotform.removeResourcesFromLabel("label_1", resources)
+    assert_equal("/v9/label/label_1/remove-resources?apiKey=test-api-key", captured[:request].path)
+    assert_equal({ "resources" => resources }.to_json, captured[:request].body)
+    assert_equal({ "ok" => true }, remove_result)
+
+    raw_payload = '{"name":"Raw Label"}'
+    raw_result = @jotform.updateLabel("label_1", raw_payload)
+    assert_equal("/v9/label/label_1?apiKey=test-api-key", captured[:request].path)
+    assert_equal(raw_payload, captured[:request].body)
+    assert_equal("application/json", captured[:request]["Content-Type"])
+    assert_equal({ "ok" => true }, raw_result)
+
+    delete_result = @jotform.deleteLabel("label_1")
+    assert_kind_of(Net::HTTP::Delete, captured[:request])
+    assert_equal("/v9/label/label_1?apiKey=test-api-key", captured[:request].path)
+    assert_equal({ "ok" => true }, delete_result)
+  end
+
   def test_get_endpoint_wrappers_call_expected_paths
     cases = [
       [:getUsage, [], "user/usage"],
+      [:getLabels, [], "user/labels"],
       [:getSubmissions, [], "user/submissions"],
       [:getSubusers, [], "user/subusers"],
       [:getFolders, [], "user/folders"],
       [:getReports, [], "user/reports"],
       [:getSettings, [], "user/settings"],
       [:getHistory, [], "user/history"],
+      [:getSystemPlan, ["FREE"], "system/plan/FREE"],
       [:getForm, ["123"], "form/123"],
       [:getFormQuestions, ["123"], "form/123/questions"],
       [:getFormQuestion, ["123", "7"], "form/123/question/7"],
@@ -132,7 +207,9 @@ class JotformTest < Test::Unit::TestCase
       [:getFormFiles, ["123"], "form/123/files"],
       [:getFormWebhooks, ["123"], "form/123/webhooks"],
       [:getReport, ["r1"], "report/r1"],
-      [:getFolder, ["fld1"], "folder/fld1"]
+      [:getFolder, ["fld1"], "folder/fld1"],
+      [:getLabel, ["lbl1"], "label/lbl1"],
+      [:getLabelResources, ["lbl1"], "label/lbl1/resources"]
     ]
 
     cases.each do |method_name, args, path|

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -1,5 +1,102 @@
 require 'test/unit'
+require 'stringio'
 require 'jotform'
 
 class JotformTest < Test::Unit::TestCase
+  class FakeSuccessResponse < Net::HTTPSuccess
+    attr_reader :body
+
+    def initialize(body)
+      @body = body
+    end
+  end
+
+  class FakeErrorResponse < Net::HTTPServerError
+    attr_reader :body
+
+    def initialize(body)
+      @body = body
+    end
+  end
+
+  def setup
+    @jotform = Jotform.new("test-api-key", "http://example.com", "v9")
+    @net_http_singleton = class << Net::HTTP; self; end
+  end
+
+  def teardown
+    restore_net_http_method(:get_response)
+    restore_net_http_method(:post_form)
+  end
+
+  def test_get_user_calls_expected_endpoint_and_returns_content
+    captured_uri = nil
+
+    stub_net_http_method(:get_response) do |uri|
+      captured_uri = uri
+      FakeSuccessResponse.new({ "content" => { "username" => "marcelo" } }.to_json)
+    end
+
+    result = @jotform.getUser
+
+    assert_equal("http://example.com/v9/user?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal({ "username" => "marcelo" }, result)
+  end
+
+  def test_create_form_webhook_posts_payload_and_returns_content
+    captured_uri = nil
+    captured_params = nil
+
+    stub_net_http_method(:post_form) do |uri, params|
+      captured_uri = uri
+      captured_params = params
+      FakeSuccessResponse.new({ "content" => { "id" => "wh_1" } }.to_json)
+    end
+
+    result = @jotform.createFormWebhook("123", "https://callback.test/hook")
+
+    assert_equal("http://example.com/v9/form/123/webhooks?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal({ "webhookURL" => "https://callback.test/hook" }, captured_params)
+    assert_equal({ "id" => "wh_1" }, result)
+  end
+
+  def test_error_response_returns_nil_and_prints_api_message
+    stub_net_http_method(:get_response) do |_uri|
+      FakeErrorResponse.new({ "message" => "Invalid API key" }.to_json)
+    end
+
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+
+    result = @jotform.getUser
+
+    assert_nil(result)
+    assert_match(/Invalid API key/, output.string)
+  ensure
+    $stdout = original_stdout
+  end
+
+  private
+
+  def stub_net_http_method(method_name, &block)
+    original_name = "__original_#{method_name}".to_sym
+    return if @net_http_singleton.method_defined?(original_name)
+
+    verbose = $VERBOSE
+    @net_http_singleton.send(:alias_method, original_name, method_name)
+    @net_http_singleton.send(:remove_method, method_name)
+    $VERBOSE = nil
+    @net_http_singleton.send(:define_method, method_name, &block)
+  ensure
+    $VERBOSE = verbose
+  end
+
+  def restore_net_http_method(method_name)
+    original_name = "__original_#{method_name}".to_sym
+    return unless @net_http_singleton.method_defined?(original_name)
+
+    @net_http_singleton.send(:alias_method, method_name, original_name)
+    @net_http_singleton.send(:remove_method, original_name)
+  end
 end

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -43,6 +43,14 @@ class JotformTest < Test::Unit::TestCase
     assert_equal({ "username" => "marcelo" }, result)
   end
 
+  def test_initialize_sets_default_values
+    jotform = Jotform.new
+
+    assert_nil(jotform.apiKey)
+    assert_equal("http://api.jotform.com", jotform.baseURL)
+    assert_equal("v1", jotform.apiVersion)
+  end
+
   def test_get_forms_calls_expected_endpoint_and_returns_content
     captured_uri = nil
 
@@ -104,6 +112,45 @@ class JotformTest < Test::Unit::TestCase
     assert_equal("http://example.com/v9/form/123/submissions?apiKey=test-api-key", captured_uri.to_s)
     assert_equal(submission_payload, captured_params)
     assert_equal({ "submissionID" => "sub_1" }, result)
+  end
+
+  def test_get_endpoint_wrappers_call_expected_paths
+    cases = [
+      [:getUsage, [], "user/usage"],
+      [:getSubmissions, [], "user/submissions"],
+      [:getSubusers, [], "user/subusers"],
+      [:getFolders, [], "user/folders"],
+      [:getReports, [], "user/reports"],
+      [:getSettings, [], "user/settings"],
+      [:getHistory, [], "user/history"],
+      [:getForm, ["123"], "form/123"],
+      [:getFormQuestions, ["123"], "form/123/questions"],
+      [:getFormQuestion, ["123", "7"], "form/123/question/7"],
+      [:getFormProperties, ["123"], "form/123/properties"],
+      [:getFormProperty, ["123", "title"], "form/123/properties/title"],
+      [:getFormSubmissions, ["123"], "form/123/submissions"],
+      [:getFormFiles, ["123"], "form/123/files"],
+      [:getFormWebhooks, ["123"], "form/123/webhooks"],
+      [:getReport, ["r1"], "report/r1"],
+      [:getFolder, ["fld1"], "folder/fld1"]
+    ]
+
+    cases.each do |method_name, args, path|
+      captured_uri = nil
+      expected_content = { "endpoint" => path }
+
+      stub_net_http_method(:get_response) do |uri|
+        captured_uri = uri
+        FakeSuccessResponse.new({ "content" => expected_content }.to_json)
+      end
+
+      result = @jotform.send(method_name, *args)
+
+      assert_equal("http://example.com/v9/#{path}?apiKey=test-api-key", captured_uri.to_s)
+      assert_equal(expected_content, result)
+
+      restore_net_http_method(:get_response)
+    end
   end
 
   def test_error_response_returns_nil_and_prints_api_message

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -96,7 +96,11 @@ class JotformTest < Test::Unit::TestCase
     original_name = "__original_#{method_name}".to_sym
     return unless @net_http_singleton.method_defined?(original_name)
 
+    verbose = $VERBOSE
+    $VERBOSE = nil
     @net_http_singleton.send(:alias_method, method_name, original_name)
     @net_http_singleton.send(:remove_method, original_name)
+  ensure
+    $VERBOSE = verbose
   end
 end

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -43,6 +43,34 @@ class JotformTest < Test::Unit::TestCase
     assert_equal({ "username" => "marcelo" }, result)
   end
 
+  def test_get_forms_calls_expected_endpoint_and_returns_content
+    captured_uri = nil
+
+    stub_net_http_method(:get_response) do |uri|
+      captured_uri = uri
+      FakeSuccessResponse.new({ "content" => [{ "id" => "f1" }] }.to_json)
+    end
+
+    result = @jotform.getForms
+
+    assert_equal("http://example.com/v9/user/forms?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal([{ "id" => "f1" }], result)
+  end
+
+  def test_get_submission_calls_expected_endpoint_and_returns_content
+    captured_uri = nil
+
+    stub_net_http_method(:get_response) do |uri|
+      captured_uri = uri
+      FakeSuccessResponse.new({ "content" => { "id" => "s1" } }.to_json)
+    end
+
+    result = @jotform.getSubmission("s1")
+
+    assert_equal("http://example.com/v9/submission/s1?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal({ "id" => "s1" }, result)
+  end
+
   def test_create_form_webhook_posts_payload_and_returns_content
     captured_uri = nil
     captured_params = nil
@@ -58,6 +86,24 @@ class JotformTest < Test::Unit::TestCase
     assert_equal("http://example.com/v9/form/123/webhooks?apiKey=test-api-key", captured_uri.to_s)
     assert_equal({ "webhookURL" => "https://callback.test/hook" }, captured_params)
     assert_equal({ "id" => "wh_1" }, result)
+  end
+
+  def test_create_form_submissions_posts_payload_and_returns_content
+    captured_uri = nil
+    captured_params = nil
+    submission_payload = { "submission[3]" => "Marcelo" }
+
+    stub_net_http_method(:post_form) do |uri, params|
+      captured_uri = uri
+      captured_params = params
+      FakeSuccessResponse.new({ "content" => { "submissionID" => "sub_1" } }.to_json)
+    end
+
+    result = @jotform.createFormSubmissions("123", submission_payload)
+
+    assert_equal("http://example.com/v9/form/123/submissions?apiKey=test-api-key", captured_uri.to_s)
+    assert_equal(submission_payload, captured_params)
+    assert_equal({ "submissionID" => "sub_1" }, result)
   end
 
   def test_error_response_returns_nil_and_prints_api_message


### PR DESCRIPTION
This pull request makes significant improvements to the Jotform Ruby API client, expanding its API coverage, improving documentation, and updating licensing. The main areas of change include enhanced endpoint support, new HTTP method handling, and improved documentation and licensing information.

**Expanded API Coverage and Methods:**

* Added support for additional Jotform API endpoints, including `/label`, `/folder`, `/system/plan/{planName}`, and more, with new methods for creating, updating, deleting, and retrieving resources such as labels, folders, reports, and system plans. [[1]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8R21-R39) [[2]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8R58-R71) [[3]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8R98-R117) [[4]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8R166-R349) [[5]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8L99-L102) [[6]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8R150-R153)
* Implemented helper methods for HTTP `PUT` and `DELETE` requests, allowing the client to interact with endpoints that require these methods. [[1]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8R21-R39) [[2]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8R58-R71)

**Documentation Improvements:**

* Updated `README.md` to use secure `https` links, clarified the main class location, and added a comprehensive list of supported endpoints as of March 8, 2026. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R74)

**Licensing and Project Configuration:**

* Changed the project license from MIT to Apache-2.0 in both the gemspec and documentation to reflect the new licensing terms. [[1]](diffhunk://#diff-a6f8418918ec218faf6a310b268567df492d727508edb8190658151ad88d45f1L17-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R74)

**Testing and Build Process:**

* Updated the `Rakefile` to ensure the `lib` directory is included in the test load path, improving test reliability.

These changes make the client more robust, up-to-date with the latest Jotform API, and easier for developers to use and contribute to.