### PR TITLE
1 update to date api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
   pull_request:
   workflow_dispatch:
-  schedule:
-    - cron: '0 8 * * 1'
 
 jobs:
   unit-and-build:
@@ -35,7 +33,7 @@ jobs:
 
   legacy-compat:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
 
     steps:
       - name: Checkout
@@ -80,7 +78,7 @@ jobs:
 
   doc-contract:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unit-and-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.1', '3.2', '3.3']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Install test dependencies
+        run: gem install rake test-unit
+
+      - name: Run unit tests
+        run: rake test
+
+      - name: Build gem package
+        run: gem build jotform_api.gemspec
+
+  integration:
+    runs-on: ubuntu-latest
+    if: ${{ secrets.JOTFORM_API_KEY != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install test dependencies
+        run: gem install rake test-unit
+
+      - name: Run integration tests
+        env:
+          JOTFORM_API_KEY: ${{ secrets.JOTFORM_API_KEY }}
+          JOTFORM_BASE_URL: https://api.jotform.com
+        run: ruby -Ilib:test test/test_jotform_integration.rb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3']
 
     steps:
       - name: Checkout
@@ -32,6 +32,25 @@ jobs:
 
       - name: Build gem package
         run: gem build jotform_api.gemspec
+
+  legacy-compat:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+
+      - name: Install test dependencies
+        run: gem install rake test-unit
+
+      - name: Run unit tests on legacy Ruby
+        run: rake test
 
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * 1'
 
 jobs:
   unit-and-build:
@@ -51,3 +54,24 @@ jobs:
           JOTFORM_API_KEY: ${{ secrets.JOTFORM_API_KEY }}
           JOTFORM_BASE_URL: https://api.jotform.com
         run: ruby -Ilib:test test/test_jotform_integration.rb
+
+  doc-contract:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install test dependencies
+        run: gem install test-unit
+
+      - name: Run docs contract test
+        env:
+          RUN_DOC_CONTRACT: '1'
+        run: ruby -Ilib:test test/test_jotform_doc_contract.rb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    if: ${{ secrets.JOTFORM_API_KEY != '' }}
 
     steps:
       - name: Checkout
@@ -53,7 +52,12 @@ jobs:
         env:
           JOTFORM_API_KEY: ${{ secrets.JOTFORM_API_KEY }}
           JOTFORM_BASE_URL: https://api.jotform.com
-        run: ruby -Ilib:test test/test_jotform_integration.rb
+        run: |
+          if [ -z "${JOTFORM_API_KEY}" ]; then
+            echo "Skipping integration tests: JOTFORM_API_KEY is not set"
+            exit 0
+          fi
+          ruby -Ilib:test test/test_jotform_integration.rb
 
   doc-contract:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ JOTFORM_API_KEY=your_api_key ruby -Ilib:test test/test_jotform_integration.rb
 
 `JOTFORM_BASE_URL` can be set for region-specific API hosts. Default is `https://api.jotform.com`.
 
+Run optional docs contract test (checks live docs endpoint list against client contract):
+
+```bash
+RUN_DOC_CONTRACT=1 ruby -Ilib:test test/test_jotform_doc_contract.rb
+```
+
 ### License
 
 This project is licensed under the Apache License 2.0. See `LICENSE.txt` for details.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ As of **March 8, 2026**, this client is aligned with the public endpoint groups 
 
 Note: API docs may change over time. When Jotform adds new endpoints, this client may require updates to stay in sync.
 
+### Testing
+
+Run unit tests:
+
+```bash
+rake test
+```
+
+Run optional integration tests (live API):
+
+```bash
+JOTFORM_API_KEY=your_api_key ruby -Ilib:test test/test_jotform_integration.rb
+```
+
+`JOTFORM_BASE_URL` can be set for region-specific API hosts. Default is `https://api.jotform.com`.
+
 ### License
 
 This project is licensed under the Apache License 2.0. See `LICENSE.txt` for details.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Note: API docs may change over time. When Jotform adds new endpoints, this clien
 
 ### Testing
 
+Supported Ruby version: `>= 3.1`
+
 Run unit tests:
 
 ```bash

--- a/jotform_api.gemspec
+++ b/jotform_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name               = "jotform_api"
-  s.version            = "1.1.0"
+  s.version            = "1.1.1"
 
   s.required_ruby_version = ">= 2.6"
   s.authors = ["Marcelo Miqueles"]

--- a/jotform_api.gemspec
+++ b/jotform_api.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
   s.name               = "jotform_api"
   s.version            = "1.1.1"
 
-  s.required_ruby_version = ">= 2.6"
+  s.required_ruby_version = ">= 3.1"
   s.authors = ["Marcelo Miqueles"]
   s.date = %q{2023-08-01}
   s.description = %q{Unofficial JotForm gem to access the JotForm API.}

--- a/lib/jotform.rb
+++ b/lib/jotform.rb
@@ -39,10 +39,18 @@ class Jotform
       response = http.request(request)
     end
 
+    parsed_body = _parse_response_body(response.body)
+
     if response.kind_of? Net::HTTPSuccess
-      return JSON.parse(response.body)["content"]
+      return parsed_body["content"] if parsed_body.is_a?(Hash)
+      return nil
     else
-      puts JSON.parse(response.body)["message"]
+      error_message = if parsed_body.is_a?(Hash)
+                        parsed_body["message"]
+                      else
+                        "Unexpected response format"
+                      end
+      puts(error_message || "Unknown API error")
       return nil
     end
   end
@@ -347,6 +355,12 @@ class Jotform
 
   def deleteReport(reportID)
     return _executeDeleteRequest("report/" + reportID)
+  end
+
+  def _parse_response_body(body)
+    JSON.parse(body)
+  rescue JSON::ParserError
+    nil
   end
 end
 

--- a/lib/jotform.rb
+++ b/lib/jotform.rb
@@ -11,7 +11,13 @@ class Jotform
   end
 
   def _executeHTTPRequest(endpoint, parameters = nil, type = "GET")
-    url = [@baseURL, @apiVersion, endpoint].join("/").concat('?apiKey='+@apiKey)
+    query_params = { "apiKey" => @apiKey }
+    if type == "GET" && parameters.is_a?(Hash)
+      query_params = query_params.merge(parameters)
+    end
+
+    url = [@baseURL, @apiVersion, endpoint].join("/")
+    url = url.concat("?").concat(URI.encode_www_form(query_params))
     url = URI.parse(url)
 
     if type == "GET"
@@ -79,12 +85,12 @@ class Jotform
     return _executeGetRequest("user/usage")
   end
 
-  def getForms
-    return _executeGetRequest("user/forms")
+  def getForms(offset = 0, limit = 0, filter = nil, orderby = nil)
+    return _executeGetRequest("user/forms", _create_conditions(offset, limit, filter, orderby))
   end
 
-  def getSubmissions
-    return _executeGetRequest("user/submissions")
+  def getSubmissions(offset = 0, limit = 0, filter = nil, orderby = nil)
+    return _executeGetRequest("user/submissions", _create_conditions(offset, limit, filter, orderby))
   end
 
   def getSubusers
@@ -111,8 +117,8 @@ class Jotform
     return _executePostRequest("user/settings", settings)
   end
 
-  def getHistory
-    return _executeGetRequest("user/history")
+  def getHistory(action = nil, date = nil, sortBy = nil, startDate = nil, endDate = nil)
+    return _executeGetRequest("user/history", _create_history_query(action, date, sortBy, startDate, endDate))
   end
 
   def getLabels
@@ -143,8 +149,8 @@ class Jotform
     return _executeGetRequest("form/"+formID+"/properties/"+propertyKey)
   end
 
-  def getFormSubmissions(formID)
-    return _executeGetRequest("form/" + formID + "/submissions")
+  def getFormSubmissions(formID, offset = 0, limit = 0, filter = nil, orderby = nil)
+    return _executeGetRequest("form/" + formID + "/submissions", _create_conditions(offset, limit, filter, orderby))
   end
 
   def getFormFiles(formID)
@@ -361,6 +367,25 @@ class Jotform
     JSON.parse(body)
   rescue JSON::ParserError
     nil
+  end
+
+  def _create_conditions(offset = 0, limit = 0, filter = nil, orderby = nil)
+    conditions = {}
+    conditions["offset"] = offset if offset && offset.to_i > 0
+    conditions["limit"] = limit if limit && limit.to_i > 0
+    conditions["filter"] = JSON.generate(filter) if filter
+    conditions["orderby"] = orderby if orderby
+    conditions
+  end
+
+  def _create_history_query(action = nil, date = nil, sortBy = nil, startDate = nil, endDate = nil)
+    history_query = {}
+    history_query["action"] = action if action
+    history_query["date"] = date if date
+    history_query["sortBy"] = sortBy if sortBy
+    history_query["startDate"] = startDate if startDate
+    history_query["endDate"] = endDate if endDate
+    history_query
   end
 end
 

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -432,6 +432,33 @@ class JotformTest < Test::Unit::TestCase
     assert_equal("/v9/report/rep_1?apiKey=test-api-key", captured[:request].path)
   end
 
+  def test_put_and_delete_use_ssl_when_base_url_is_https
+    jotform_https = Jotform.new("test-api-key", "https://api.jotform.com", "v1")
+    captured = {}
+
+    stub_net_http_method(:new) do |_host, _port|
+      http = Object.new
+      http.define_singleton_method(:use_ssl=) do |value|
+        captured[:use_ssl] = value
+      end
+      http.define_singleton_method(:request) do |request|
+        captured[:request] = request
+        FakeSuccessResponse.new({ "content" => { "ok" => true } }.to_json)
+      end
+      http
+    end
+
+    put_result = jotform_https.updateLabel("label_1", { "name" => "Secure" })
+    assert_equal(true, captured[:use_ssl])
+    assert_kind_of(Net::HTTP::Put, captured[:request])
+    assert_equal({ "ok" => true }, put_result)
+
+    delete_result = jotform_https.deleteLabel("label_1")
+    assert_equal(true, captured[:use_ssl])
+    assert_kind_of(Net::HTTP::Delete, captured[:request])
+    assert_equal({ "ok" => true }, delete_result)
+  end
+
   def test_get_endpoint_wrappers_call_expected_paths
     cases = [
       [:getUsage, [], "user/usage"],

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -74,6 +74,41 @@ class JotformTest < Test::Unit::TestCase
     assert_equal([{ "id" => "f1" }], result)
   end
 
+  def test_get_endpoints_support_query_params
+    captured_uri = nil
+
+    stub_net_http_method(:get_response) do |uri|
+      captured_uri = uri
+      FakeSuccessResponse.new({ "content" => { "ok" => true } }.to_json)
+    end
+
+    @jotform.getForms(5, 20, { "id:gt" => "100" }, "created_at")
+    assert_equal("/v9/user/forms", captured_uri.path)
+    query = URI.decode_www_form(captured_uri.query).to_h
+    assert_equal("test-api-key", query["apiKey"])
+    assert_equal("5", query["offset"])
+    assert_equal("20", query["limit"])
+    assert_equal('{"id:gt":"100"}', query["filter"])
+    assert_equal("created_at", query["orderby"])
+
+    @jotform.getHistory("FORM_CREATE", "MONTH", "DESC", "01/01/2026", "01/31/2026")
+    assert_equal("/v9/user/history", captured_uri.path)
+    query = URI.decode_www_form(captured_uri.query).to_h
+    assert_equal("FORM_CREATE", query["action"])
+    assert_equal("MONTH", query["date"])
+    assert_equal("DESC", query["sortBy"])
+    assert_equal("01/01/2026", query["startDate"])
+    assert_equal("01/31/2026", query["endDate"])
+
+    @jotform.getFormSubmissions("123", 10, 50, { "status:eq" => "ACTIVE" }, "created_at")
+    assert_equal("/v9/form/123/submissions", captured_uri.path)
+    query = URI.decode_www_form(captured_uri.query).to_h
+    assert_equal("10", query["offset"])
+    assert_equal("50", query["limit"])
+    assert_equal('{"status:eq":"ACTIVE"}', query["filter"])
+    assert_equal("created_at", query["orderby"])
+  end
+
   def test_get_submission_calls_expected_endpoint_and_returns_content
     captured_uri = nil
 
@@ -465,6 +500,25 @@ class JotformTest < Test::Unit::TestCase
     assert_match(/Unexpected response format/, output.string)
   ensure
     $stdout = original_stdout
+  end
+
+  def test_public_api_contract_includes_expected_methods
+    expected_methods = %w[
+      getUser getUsage getForms getSubmissions getSubusers getFolders getReports getSettings
+      getUserSetting updateSettings getHistory getLabels getInvoices getForm getFormQuestions
+      getFormQuestion getFormProperties getFormProperty getFormSubmissions getFormFiles
+      getFormWebhooks getFormReports getSubmission getReport getFolder getSystemPlan getLabel
+      getLabelResources createFormWebhook deleteFormWebhook createFormSubmissions createFormSubmission
+      editSubmission deleteSubmission createLabel updateLabel addResourcesToLabel removeResourcesFromLabel
+      deleteLabel createFolder updateFolder deleteFolder addFormsToFolder addFormToFolder cloneForm
+      createFormQuestion createFormQuestions editFormQuestion deleteFormQuestion setFormProperties
+      setMultipleFormProperties createForm createForms deleteForm registerUser loginUser logoutUser
+      createReport deleteReport
+    ]
+
+    expected_methods.each do |method_name|
+      assert_respond_to(@jotform, method_name.to_sym)
+    end
   end
 
   private

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -19,6 +19,14 @@ class JotformTest < Test::Unit::TestCase
     end
   end
 
+  class FakeUnauthorizedResponse < Net::HTTPUnauthorized
+    attr_reader :body
+
+    def initialize(body)
+      @body = body
+    end
+  end
+
   def setup
     @jotform = Jotform.new("test-api-key", "http://example.com", "v9")
     @net_http_singleton = class << Net::HTTP; self; end
@@ -394,6 +402,67 @@ class JotformTest < Test::Unit::TestCase
 
     assert_nil(result)
     assert_match(/Invalid API key/, output.string)
+  ensure
+    $stdout = original_stdout
+  end
+
+  def test_error_response_with_missing_message_prints_fallback
+    stub_net_http_method(:get_response) do |_uri|
+      FakeErrorResponse.new({ "code" => 500 }.to_json)
+    end
+
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+
+    result = @jotform.getUser
+
+    assert_nil(result)
+    assert_match(/Unknown API error/, output.string)
+  ensure
+    $stdout = original_stdout
+  end
+
+  def test_unauthorized_response_returns_nil_and_prints_message
+    stub_net_http_method(:get_response) do |_uri|
+      FakeUnauthorizedResponse.new({ "message" => "Unauthorized" }.to_json)
+    end
+
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+
+    result = @jotform.getUser
+
+    assert_nil(result)
+    assert_match(/Unauthorized/, output.string)
+  ensure
+    $stdout = original_stdout
+  end
+
+  def test_success_response_with_malformed_json_returns_nil
+    stub_net_http_method(:get_response) do |_uri|
+      FakeSuccessResponse.new("not-json")
+    end
+
+    result = @jotform.getUser
+
+    assert_nil(result)
+  end
+
+  def test_error_response_with_malformed_json_returns_nil_and_prints_unexpected_format
+    stub_net_http_method(:get_response) do |_uri|
+      FakeErrorResponse.new("not-json")
+    end
+
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+
+    result = @jotform.getUser
+
+    assert_nil(result)
+    assert_match(/Unexpected response format/, output.string)
   ensure
     $stdout = original_stdout
   end

--- a/test/test_jotform.rb
+++ b/test/test_jotform.rb
@@ -27,6 +27,30 @@ class JotformTest < Test::Unit::TestCase
     end
   end
 
+  class FakeForbiddenResponse < Net::HTTPForbidden
+    attr_reader :body
+
+    def initialize(body)
+      @body = body
+    end
+  end
+
+  class FakeNotFoundResponse < Net::HTTPNotFound
+    attr_reader :body
+
+    def initialize(body)
+      @body = body
+    end
+  end
+
+  class FakeTooManyRequestsResponse < Net::HTTPTooManyRequests
+    attr_reader :body
+
+    def initialize(body)
+      @body = body
+    end
+  end
+
   def setup
     @jotform = Jotform.new("test-api-key", "http://example.com", "v9")
     @net_http_singleton = class << Net::HTTP; self; end
@@ -107,6 +131,37 @@ class JotformTest < Test::Unit::TestCase
     assert_equal("50", query["limit"])
     assert_equal('{"status:eq":"ACTIVE"}', query["filter"])
     assert_equal("created_at", query["orderby"])
+  end
+
+  def test_query_params_handle_special_characters_and_complex_filters
+    captured_uri = nil
+
+    stub_net_http_method(:get_response) do |uri|
+      captured_uri = uri
+      FakeSuccessResponse.new({ "content" => { "ok" => true } }.to_json)
+    end
+
+    @jotform.getForms(
+      1,
+      25,
+      { "status:eq" => "ACTIVE", "title:contains" => "Sales & Marketing" },
+      "created_at desc"
+    )
+
+    assert_equal("/v9/user/forms", captured_uri.path)
+    query = URI.decode_www_form(captured_uri.query).to_h
+    assert_equal("test-api-key", query["apiKey"])
+    assert_equal("1", query["offset"])
+    assert_equal("25", query["limit"])
+    assert_equal('{"status:eq":"ACTIVE","title:contains":"Sales & Marketing"}', query["filter"])
+    assert_equal("created_at desc", query["orderby"])
+
+    @jotform.getHistory(nil, nil, "ASC", "03/01/2026 10:30", "03/08/2026 18:45")
+    assert_equal("/v9/user/history", captured_uri.path)
+    query = URI.decode_www_form(captured_uri.query).to_h
+    assert_equal("ASC", query["sortBy"])
+    assert_equal("03/01/2026 10:30", query["startDate"])
+    assert_equal("03/08/2026 18:45", query["endDate"])
   end
 
   def test_get_submission_calls_expected_endpoint_and_returns_content
@@ -498,6 +553,57 @@ class JotformTest < Test::Unit::TestCase
 
     assert_nil(result)
     assert_match(/Unexpected response format/, output.string)
+  ensure
+    $stdout = original_stdout
+  end
+
+  def test_error_response_forbidden_returns_nil_and_prints_message
+    stub_net_http_method(:get_response) do |_uri|
+      FakeForbiddenResponse.new({ "message" => "Forbidden" }.to_json)
+    end
+
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+
+    result = @jotform.getUser
+
+    assert_nil(result)
+    assert_match(/Forbidden/, output.string)
+  ensure
+    $stdout = original_stdout
+  end
+
+  def test_error_response_not_found_returns_nil_and_prints_message
+    stub_net_http_method(:get_response) do |_uri|
+      FakeNotFoundResponse.new({ "message" => "Not Found" }.to_json)
+    end
+
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+
+    result = @jotform.getForm("does-not-exist")
+
+    assert_nil(result)
+    assert_match(/Not Found/, output.string)
+  ensure
+    $stdout = original_stdout
+  end
+
+  def test_error_response_too_many_requests_returns_nil_and_prints_message
+    stub_net_http_method(:get_response) do |_uri|
+      FakeTooManyRequestsResponse.new({ "message" => "Rate limit exceeded" }.to_json)
+    end
+
+    original_stdout = $stdout
+    output = StringIO.new
+    $stdout = output
+
+    result = @jotform.getForms
+
+    assert_nil(result)
+    assert_match(/Rate limit exceeded/, output.string)
   ensure
     $stdout = original_stdout
   end

--- a/test/test_jotform_doc_contract.rb
+++ b/test/test_jotform_doc_contract.rb
@@ -1,0 +1,81 @@
+require 'test/unit'
+require 'open-uri'
+
+class JotformDocContractTest < Test::Unit::TestCase
+  DOCS_URL = 'https://api.jotform.com/docs/'.freeze
+
+  SUPPORTED_ENDPOINTS = [
+    'user',
+    'user/forms',
+    'user/folders',
+    'user/invoices',
+    'user/history',
+    'user/settings',
+    'user/settings/{settingsKey}',
+    'user/subusers',
+    'user/usage',
+    'user/reports',
+    'user/register',
+    'user/login',
+    'user/logout',
+    'user/submissions',
+    'user/labels',
+    'form/{formID}',
+    'form/{formID}/clone',
+    'form/{formID}/files',
+    'form/{formID}/properties',
+    'form/{formID}/properties/{propertyKey}',
+    'form/{formID}/question/{questionID}',
+    'form/{formID}/questions',
+    'form/{formID}/reports',
+    'form/{formID}/submissions',
+    'form/{formID}/webhooks',
+    'form/{formID}/webhooks/{webhookID}',
+    'report/{reportID}',
+    'submission/{submissionID}',
+    'folder',
+    'folder/{folderID}',
+    'system/plan/{planName}',
+    'label',
+    'label/{labelID}',
+    'label/{labelID}/resources',
+    'label/{labelID}/add-resources',
+    'label/{labelID}/remove-resources'
+  ].freeze
+
+  def test_docs_endpoints_are_covered_by_client_contract
+    omit('Set RUN_DOC_CONTRACT=1 to run doc contract test') unless ENV['RUN_DOC_CONTRACT'] == '1'
+
+    html = URI.open(DOCS_URL, &:read)
+    documented = extract_documented_endpoints(html)
+    missing = documented - SUPPORTED_ENDPOINTS
+
+    assert(
+      missing.empty?,
+      "Documented endpoints missing from client contract:\n#{missing.sort.join("\n")}"
+    )
+  end
+
+  private
+
+  def extract_documented_endpoints(html)
+    endpoints = html.scan(%r{https://api\.jotform\.com/(?:v1/)?[a-zA-Z0-9_\-\{\}/]+}).map do |full|
+      normalize_endpoint(full.sub('https://api.jotform.com/', ''))
+    end
+
+    endpoints.reject { |ep| ep.nil? || ep == 'docs/' }.uniq.sort
+  end
+
+  def normalize_endpoint(endpoint)
+    ep = endpoint.dup
+    ep = ep.sub(%r{\Av1/}, '')
+    ep = ep.sub('{myFormID}', '{formID}')
+    ep = ep.sub(%r{\Asystem/plan/[^/]+\z}, 'system/plan/{planName}')
+    ep = ep.sub(%r{\Aform\z}, 'user/forms')
+    ep = ep.sub(%r{\Alabel/[0-9a-f]{20,}\z}, 'label/{labelID}')
+    ep = ep.sub(%r{\Alabel/[0-9a-f]{20,}/resources\z}, 'label/{labelID}/resources')
+    ep = ep.sub(%r{\Alabel/[0-9a-f]{20,}/add-resources\z}, 'label/{labelID}/add-resources')
+    ep = ep.sub(%r{\Alabel/[0-9a-f]{20,}/remove-resources\z}, 'label/{labelID}/remove-resources')
+    ep
+  end
+end

--- a/test/test_jotform_integration.rb
+++ b/test/test_jotform_integration.rb
@@ -1,0 +1,33 @@
+require 'test/unit'
+require 'jotform'
+
+class JotformIntegrationTest < Test::Unit::TestCase
+  def setup
+    api_key = ENV['JOTFORM_API_KEY']
+    omit('Set JOTFORM_API_KEY to run integration tests') if api_key.nil? || api_key.empty?
+
+    base_url = ENV.fetch('JOTFORM_BASE_URL', 'https://api.jotform.com')
+    @jotform = Jotform.new(api_key, base_url, 'v1')
+  end
+
+  def test_get_user_returns_hash
+    response = @jotform.getUser
+
+    assert_not_nil(response)
+    assert_kind_of(Hash, response)
+  end
+
+  def test_get_usage_returns_hash
+    response = @jotform.getUsage
+
+    assert_not_nil(response)
+    assert_kind_of(Hash, response)
+  end
+
+  def test_get_forms_returns_array_or_hash
+    response = @jotform.getForms
+
+    assert_not_nil(response)
+    assert(response.is_a?(Array) || response.is_a?(Hash), 'Expected Array or Hash response from getForms')
+  end
+end

--- a/test/test_packaging.rb
+++ b/test/test_packaging.rb
@@ -1,0 +1,17 @@
+require 'test/unit'
+require 'tmpdir'
+
+class PackagingTest < Test::Unit::TestCase
+  def test_gem_build_succeeds_and_produces_expected_artifact
+    expected_gem_name = 'jotform_api-1.1.0.gem'
+
+    Dir.mktmpdir('jotform-gem-build') do |dir|
+      output = `gem build jotform_api.gemspec --output #{File.join(dir, expected_gem_name)} 2>&1`
+      assert_equal(0, $?.exitstatus, "gem build failed:\n#{output}")
+
+      artifact = File.join(dir, expected_gem_name)
+      assert(File.exist?(artifact), "Expected built gem artifact at #{artifact}")
+      assert(File.size(artifact) > 0, 'Built gem artifact is empty')
+    end
+  end
+end

--- a/test/test_packaging.rb
+++ b/test/test_packaging.rb
@@ -3,7 +3,8 @@ require 'tmpdir'
 
 class PackagingTest < Test::Unit::TestCase
   def test_gem_build_succeeds_and_produces_expected_artifact
-    expected_gem_name = 'jotform_api-1.1.0.gem'
+    spec = Gem::Specification.load('jotform_api.gemspec')
+    expected_gem_name = "jotform_api-#{spec.version}.gem"
 
     Dir.mktmpdir('jotform-gem-build') do |dir|
       output = `gem build jotform_api.gemspec --output #{File.join(dir, expected_gem_name)} 2>&1`


### PR DESCRIPTION
This pull request introduces several significant improvements to the Jotform API Ruby client, focusing on enhanced API query parameter support, improved error handling, expanded test coverage (including integration and documentation contract tests), and updated CI workflows to ensure compatibility and reliability. The changes also update the required Ruby version and documentation accordingly.

**Key changes include:**

### API Enhancements and Error Handling

- Added support for passing query parameters (offset, limit, filter, orderby) to methods like `getForms`, `getSubmissions`, `getFormSubmissions`, and `getHistory`, allowing for more flexible and powerful API queries. Helper methods `_create_conditions` and `_create_history_query` were introduced to build these parameters. (`lib/jotform.rb`) [[1]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8L74-R93) [[2]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8L106-R121) [[3]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8L138-R153) [[4]](diffhunk://#diff-4acdf91daeb12dfa48aee7e60a6e97c47a0f1f434a34222ef9b57814f92c70f8R365-R389)
- Improved error handling in `_executeHTTPRequest` to gracefully handle malformed JSON responses and print appropriate error messages, including handling cases where the API response does not include a message. (`lib/jotform.rb`)

### Testing and Quality Assurance

- Added comprehensive unit tests for query parameter handling, error scenarios (including unauthorized, forbidden, not found, rate limit, and malformed responses), and SSL usage for HTTPS endpoints. (`test/test_jotform.rb`) [[1]](diffhunk://#diff-0fbdc3a7482010c7d3280d8dce0a974ad102b7d06b98623430b8f01922691d05R101-R166) [[2]](diffhunk://#diff-0fbdc3a7482010c7d3280d8dce0a974ad102b7d06b98623430b8f01922691d05R435-R461) [[3]](diffhunk://#diff-0fbdc3a7482010c7d3280d8dce0a974ad102b7d06b98623430b8f01922691d05R526-R656)
- Introduced an integration test suite that runs against the live Jotform API if `JOTFORM_API_KEY` is set, verifying real-world client behavior. (`test/test_jotform_integration.rb`)
- Added a documentation contract test to ensure the client’s supported endpoints stay aligned with the official Jotform API documentation. (`test/test_jotform_doc_contract.rb`)
- Added a packaging test to verify that the gem builds successfully and produces the expected artifact. (`test/test_packaging.rb`)

### Continuous Integration and Documentation

- Introduced a new GitHub Actions CI workflow that runs unit tests, integration tests, legacy compatibility checks, and documentation contract tests across supported Ruby versions. (`.github/workflows/ci.yml`)
- Updated the `README.md` with clear instructions for running tests and integration checks, and clarified supported Ruby versions.

### Versioning and Compatibility

- Updated the gemspec to require Ruby >= 3.1 and bumped the gem version to `1.1.1` to reflect these changes. (`jotform_api.gemspec`)

These changes collectively improve the reliability, flexibility, and maintainability of the client, while ensuring ongoing compatibility with the evolving Jotform API.